### PR TITLE
Correct typos

### DIFF
--- a/toy-density-estimation/vanilla_diffusion_model.ipynb
+++ b/toy-density-estimation/vanilla_diffusion_model.ipynb
@@ -85,7 +85,7 @@
     "data = torch.vstack([y, x])\n",
     "\n",
     "def transform(data):\n",
-    "    min_, max_ = torch.min(data, axis=1), torch.max(data, axis=1)\n",
+    "    min_, max_ = torch.min(data, dim=1), torch.max(data, dim=1)\n",
     "    data_transformed = 2 * (data.sub(min_.values[:, None])).div((max_.values - min_.values)[:, None]) - 1\n",
     "    return data_transformed, min_, max_\n",
     "\n",
@@ -195,7 +195,7 @@
     "# betas = linear_beta_schedule(timesteps)\n",
     "betas = linear_beta_schedule(timesteps)\n",
     "alphas = 1 - betas\n",
-    "alphas_ = torch.cumprod(alphas, axis=0)\n",
+    "alphas_ = torch.cumprod(alphas, dim=0)\n",
     "variance = 1 - alphas_\n",
     "sd = torch.sqrt(variance)\n",
     "\n",
@@ -213,7 +213,7 @@
     "added_noise_at_t = get_noisy(data_transformed, timesteps-1)\n",
     "plt.scatter(added_noise_at_t[0], added_noise_at_t[1])\n",
     "\n",
-    "posterior_variance = (1 - alphas) * (1 - alphas_prev_) / (1 - alphas)"
+    "posterior_variance = (1 - alphas) * (1 - alphas_prev_) / (1 - alphas_)"
    ]
   },
   {
@@ -857,7 +857,7 @@
     "            posterior_data = posterior_variance[timestep]\n",
     "            data_in_batch = torch.normal(mean_data, torch.sqrt(posterior_data)).T\n",
     "            datas.append(data_in_batch.cpu().detach())\n",
-    "    return datas, data_in_batch\n",
+    "    return datas, data_in_batch.cpu().detach()\n",
     "\n",
     "datas, data_in_batch = generate_data(denoising_model)"
    ]
@@ -890,8 +890,7 @@
     }
    ],
    "source": [
-    "data_in_batch = data_in_batch.cpu().detach()\n",
-    "data_pred = reverse_transform(data_in_batch.cpu().detach(), min_, max_)\n",
+    "data_pred = reverse_transform(data_in_batch, min_, max_)\n",
     "_, (ax1, ax2) = plt.subplots(1, 2)\n",
     "\n",
     "ax1.scatter(data[0], data[1])\n",
@@ -1266,8 +1265,7 @@
     }
    ],
    "source": [
-    "data_in_batch = data_in_batch.cpu().detach()\n",
-    "data_pred = reverse_transform(data_in_batch.cpu().detach(), min_circles, max_circles)\n",
+    "data_pred = reverse_transform(data_in_batch, min_circles, max_circles)\n",
     "_, (ax1, ax2) = plt.subplots(1, 2)\n",
     "\n",
     "ax1.scatter(circles[0], circles[1])\n",
@@ -1517,8 +1515,7 @@
     }
    ],
    "source": [
-    "data_in_batch = data_in_batch.cpu().detach()\n",
-    "data_pred = reverse_transform(data_in_batch.cpu().detach(), min_moons, max_moons)\n",
+    "data_pred = reverse_transform(data_in_batch, min_moons, max_moons)\n",
     "_, (ax1, ax2) = plt.subplots(1, 2)\n",
     "\n",
     "ax1.scatter(make_moons[0], make_moons[1])\n",
@@ -1780,8 +1777,7 @@
     }
    ],
    "source": [
-    "data_in_batch = data_in_batch.cpu().detach()\n",
-    "data_pred = reverse_transform(data_in_batch.cpu().detach(), min_complex, max_complex)\n",
+    "data_pred = reverse_transform(data_in_batch, min_complex, max_complex)\n",
     "_, (ax1, ax2) = plt.subplots(1, 2)\n",
     "\n",
     "ax1.scatter(complex_data[0], complex_data[1])\n",


### PR DESCRIPTION
 - There is an error in the posterior_variance definition that should be divided by (1 - alpha_) otherwise the (1 - alpha) are cancelling each other out.
 - torch.min, torch.max and torch.cumprod should be dim and not axis
 - Detach the last timestep of the batch data in generate_data so that there is no need to do it after when calling generate_data